### PR TITLE
埋め込みURLを通常のURLに変換する

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "daraz-tek bot nya-n",
   "dependencies": {
     "cron": "^1.0.9",
+    "get-video-id": "0.0.6",
     "hubot": "^2.17.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-docomochatter": "0.1.0",

--- a/scripts/apod.coffee
+++ b/scripts/apod.coffee
@@ -1,11 +1,17 @@
 request = require "request"
+get_video_id = require "get-video-id"
+
 API_KEY = "Q8mtkFkP4Zru4mlDd812iw2vcQwx5B0qIsUKsxit"
 
 module.exports = (robot) ->
-  robot.hear /apod|galaxy|spa+ce|宇宙|コスモ|銀河/i, (msg) ->
-    request "https://api.nasa.gov/planetary/apod?api_key=#{API_KEY}", (error, responce, body) ->
-      if not error and responce.statusCode is 200
-      	dict = JSON.parse body
-      	msg.reply "宇宙って良いにゃーん\n#{dict.title}\n#{dict.url}"
-      else
-      	msg.reply "APODの画像が取れなかったにゃーん"
+	robot.hear /apod|galaxy|spa+ce|宇宙|コスモ|銀河/i, (msg) ->
+		request "https://api.nasa.gov/planetary/apod?api_key=#{API_KEY}", (error, responce, body) ->
+			if not error and responce.statusCode is 200
+				dict = JSON.parse body
+				url =
+					if dict.media_type is "video"
+					then "https://www.youtube.com/watch?v=#{get_video_id(dict.url)}"
+					else dict.url
+				msg.reply "宇宙って良いにゃーん\n#{dict.title}\n#{url}"
+			else
+				msg.reply "APODの画像が取れなかったにゃーん"


### PR DESCRIPTION
NASA APOD APIは動画のURLを埋め込み用のまま返す。
これはSlack上でサムネイルが表示されないという問題を起こす。
このPRは、URLを正規化する処理を付け加えるものである。
